### PR TITLE
pred_by_rel_distance to return None if can't divide by 0 concepts

### DIFF
--- a/regression_utils.py
+++ b/regression_utils.py
@@ -15,7 +15,8 @@ def pred_by_rel_distance(y_test
     df = DataFrame(dict)
     df = df.reset_index()
     df['rel_diff'] = df.apply(lambda x: None if x.concept == 0.0 else x.classifier/x.concept, axis=1)
-    df['threshold_rel_diff'] = df.rel_diff.map(lambda x: x > (1 - threshold) and x < (1 + threshold))
+    df['threshold_rel_diff'] = df.rel_diff.map(lambda x: None if (x is None) else x > (1 - threshold) and x < (1 + threshold))
+
 
     return df['threshold_rel_diff'].mean()
 


### PR DESCRIPTION
pred_by_rel_distance() currently checks if the concept is 0, and if so, sets rel_diff to None, to avoid division by zero.
But then, it tries to see if rel_diff (which is None) is within _threshold_ of 1, which raises an exception.
I've added a safeguard for this edge case, returning None, instead of raising an error.